### PR TITLE
Implemented Headless Chrome to enable server-side automation

### DIFF
--- a/checkout-enroll.py
+++ b/checkout-enroll.py
@@ -32,6 +32,24 @@ if session.query(Course).filter(Course.discounted_price == 0).filter(Course.rema
     print("no courses to enroll. summarising and quitting...\n")
 
 else:
+    ############ Uncomment this to use the new Headless Chrome browser - No GUI and enables server-side automation ##########
+    ############ Verified to work on Mac OSX, have not tested for Windows. ##################################################
+    ############ Headless Chrome is new and Windows was last to be implemented ##############################################
+    ## We can customize our webdriver using
+    #options = webdriver.ChromeOptions()
+    ## This option implements Chrome Headless, a new (late 2017) GUI-less browser that allows flexibility with server-side web automation
+    ## Must be Chromedriver 2.9 and above (chromedriverheadless is 2.33)
+    #options.add_argument('--headless')
+    ## When using a Chrome's headless browser, it's 'user agent' (which is it's identity in source code) is HeadlessChrome, 
+    ## which 3rd party bot tracking software will try to identify and block by forcing a CAPTCHA.
+    ## Therefore we specify the desired user agent to be "Chrome", tricking the detection software.
+    ## It can actually literally be anything other than HeadlessChrome, but this makes the most sense.
+    #user_agent = "Chrome"
+    #options.add_argument(f'user-agent={user_agent}')
+    #UDEMY_FOLDER_PATH = UDEMY_FOLDER_PATH + "chromedriverheadless" # + "chromedriverheadless.exe" for Windows users
+    #driver = webdriver.Chrome(UDEMY_FOLDER_PATH, chrome_options=options)
+    ###############################################################################################################################
+    
     UDEMY_FOLDER_PATH = UDEMY_FOLDER_PATH + "chromedriver.exe" # + "chromedriver" for Mac users
     driver = webdriver.Chrome(UDEMY_FOLDER_PATH)
     driver.get("https://www.udemy.com/join/login-popup/")

--- a/reddit-checkout-enroll.py
+++ b/reddit-checkout-enroll.py
@@ -40,6 +40,24 @@ if session.query(Course).filter(Course.discounted_price == 0).filter(Course.rema
     print("no courses to enroll from reddit. summarising and quitting...\n")
 
 else:
+    ############ Uncomment this to use the new Headless Chrome browser - No GUI and enables server-side automation ##########
+    ############ Verified to work on Mac OSX, have not tested for Windows. ##################################################
+    ############ Headless Chrome is new and Windows was last to be implemented ##############################################
+    ## We can customize our webdriver using
+    #options = webdriver.ChromeOptions()
+    ## This option implements Chrome Headless, a new (late 2017) GUI-less browser that allows flexibility with server-side web automation
+    ## Must be Chromedriver 2.9 and above (chromedriverheadless is 2.33)
+    #options.add_argument('--headless')
+    ## When using a Chrome's headless browser, it's 'user agent' (which is it's identity in source code) is HeadlessChrome, 
+    ## which 3rd party bot tracking software will try to identify and block by forcing a CAPTCHA.
+    ## Therefore we specify the desired user agent to be "Chrome", tricking the detection software.
+    ## It can actually literally be anything other than HeadlessChrome, but this makes the most sense.
+    #user_agent = "Chrome"
+    #options.add_argument(f'user-agent={user_agent}')
+    #UDEMY_FOLDER_PATH = UDEMY_FOLDER_PATH + "chromedriverheadless" # + "chromedriverheadless.exe" for Windows users
+    #driver = webdriver.Chrome(UDEMY_FOLDER_PATH, chrome_options=options)
+    ###############################################################################################################################
+    
     UDEMY_FOLDER_PATH = UDEMY_FOLDER_PATH + "chromedriver.exe" # + "chromedriver" for Mac users
     driver = webdriver.Chrome(UDEMY_FOLDER_PATH)
     driver.get("https://www.udemy.com/join/login-popup/")


### PR DESCRIPTION
Headless Chrome is a new feature in Chrome that runs the browser in a headless environment - no GUI, but with all the features of Chrome through the CLI!

The purpose of a headless browser is for automated testing and server
environments where you don't need a visible UI shell. For example, you
may want to run some tests against a real web page, create a PDF of it,
or just inspect how the browser renders a URL. There are many options,
consult the docs for more info.

Verified to work on Mac OSX, have not tested for Windows.
Windows release was supposed to come with Chrome 60, however I’ve heard there may still be issues.